### PR TITLE
add metadata to data-fetchers

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherMetadata.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherMetadata.java
@@ -1,0 +1,14 @@
+package com.intuit.graphql.orchestrator.datafetcher;
+
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
+import lombok.Getter;
+
+@Getter
+public class DataFetcherMetadata {
+
+  private final DataFetcherContext dataFetcherContext;
+
+  public DataFetcherMetadata(DataFetcherContext dataFetcherContext) {
+    this.dataFetcherContext = dataFetcherContext;
+  }
+}

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
@@ -1,31 +1,26 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
 import com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDataLoaderUtil;
-import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Objects;
 
-public class FieldResolverDirectiveDataFetcher implements DataFetcher<Object> {
+public class FieldResolverDirectiveDataFetcher extends DataFetcherMetadata implements DataFetcher<Object> {
 
-  private final FieldResolverContext fieldResolverContext;
 
-  private FieldResolverDirectiveDataFetcher(FieldResolverContext fieldResolverContext) {
-    this.fieldResolverContext = fieldResolverContext;
-  }
-
-  public static FieldResolverDirectiveDataFetcher from(DataFetcherContext dataFetcherContext) {
+  public FieldResolverDirectiveDataFetcher(DataFetcherContext dataFetcherContext) {
+    super(dataFetcherContext);
     Objects.requireNonNull(dataFetcherContext, "DataFetcherContext is required");
     Objects.requireNonNull(dataFetcherContext.getFieldResolverContext(),
         "FieldResolverContext is required");
-    return new FieldResolverDirectiveDataFetcher(dataFetcherContext.getFieldResolverContext());
   }
 
   @Override
   public Object get(final DataFetchingEnvironment dataFetchingEnvironment) {
     return dataFetchingEnvironment
-        .getDataLoader(FieldResolverDataLoaderUtil.createDataLoaderKeyFrom(fieldResolverContext))
+        .getDataLoader(
+            FieldResolverDataLoaderUtil.createDataLoaderKeyFrom(getDataFetcherContext().getFieldResolverContext()))
         .load(dataFetchingEnvironment);
   }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
@@ -6,6 +6,7 @@ import static graphql.language.AstPrinter.printAstCompact;
 import com.intuit.graphql.orchestrator.batch.DefaultQueryResponseModifier;
 import com.intuit.graphql.orchestrator.batch.QueryResponseModifier;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
 import graphql.language.Document;
@@ -17,12 +18,13 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 
-public class RestDataFetcher implements DataFetcher {
+public class RestDataFetcher extends DataFetcherMetadata implements DataFetcher {
 
   private final ServiceMetadata serviceMetadata;
   private final QueryResponseModifier queryResponseModifier = new DefaultQueryResponseModifier();
 
-  public RestDataFetcher(final ServiceMetadata serviceMetadata) {
+  public RestDataFetcher(final ServiceMetadata serviceMetadata, final DataFetcherContext dataFetcherContext) {
+    super(dataFetcherContext);
     this.serviceMetadata = serviceMetadata;
   }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
@@ -1,13 +1,14 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import graphql.GraphQLContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import lombok.Getter;
 
 @Getter
-public class ServiceDataFetcher implements DataFetcher {
+public class ServiceDataFetcher extends DataFetcherMetadata implements DataFetcher {
 
   /**
    * One of Query or Mutation or Subscription
@@ -15,7 +16,8 @@ public class ServiceDataFetcher implements DataFetcher {
   private final ServiceMetadata serviceMetadata;
 
 
-  public ServiceDataFetcher(ServiceMetadata serviceMetadata) {
+  public ServiceDataFetcher(ServiceMetadata serviceMetadata, DataFetcherContext dataFetcherContext) {
+    super(dataFetcherContext);
     this.serviceMetadata = serviceMetadata;
   }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
@@ -109,9 +109,9 @@ public class XtextStitcher implements Stitcher {
 
     stitchedTransformedGraph.getFieldResolverContexts().forEach(fieldResolverContext -> {
       FieldResolverBatchLoader fieldResolverDataLoader = FieldResolverBatchLoader
-              .builder()
-              .fieldResolverContext(fieldResolverContext)
-              .build();
+          .builder()
+          .fieldResolverContext(fieldResolverContext)
+          .build();
 
       String batchLoaderKey = FieldResolverDataLoaderUtil.createDataLoaderKeyFrom(fieldResolverContext);
       batchLoaders.put(batchLoaderKey, fieldResolverDataLoader);
@@ -142,7 +142,8 @@ public class XtextStitcher implements Stitcher {
 
     HashMap<String, BatchLoader> batchLoaderMap = new HashMap<>();
     xtextGraphMap.forEach((namespace, graph) -> {
-      if (graph.getServiceProvider().getSeviceType() == ServiceType.GRAPHQL || graph.getServiceProvider().isFederationProvider()) {
+      if (graph.getServiceProvider().getSeviceType() == ServiceType.GRAPHQL || graph.getServiceProvider()
+          .isFederationProvider()) {
         batchLoaderMap.put(namespace,
             GraphQLServiceBatchLoader
                 .newQueryExecutorBatchLoader()
@@ -177,8 +178,8 @@ public class XtextStitcher implements Stitcher {
         final XtextGraph serviceMetadata = graphsByNamespace.get(dataFetcherContext.getNamespace());
         builder.dataFetcher(coordinates,
             dataFetcherContext.getServiceType() == ServiceType.REST
-                ? new RestDataFetcher(serviceMetadata)
-                : new ServiceDataFetcher(serviceMetadata)
+                ? new RestDataFetcher(serviceMetadata, dataFetcherContext)
+                : new ServiceDataFetcher(serviceMetadata, dataFetcherContext)
         );
       } else if (type == RESOLVER_ARGUMENT) {
         final XtextToGraphQLJavaVisitor visitor = XtextToGraphQLJavaVisitor.newBuilder().build();
@@ -192,13 +193,12 @@ public class XtextStitcher implements Stitcher {
                 Collectors.toMap(Function.identity(), d -> queryBuilder.buildQuery(d.getField(), d.getInputType())));
 
         builder.dataFetcher(coordinates, ResolverArgumentDataFetcher.newBuilder()
-            .namespace(dataFetcherContext.getNamespace())
+            .dataFetcherContext(dataFetcherContext)
             .queriesByResolverArgument(map)
             .build()
         );
       } else if (type == RESOLVER_ON_FIELD_DEFINITION) {
-        builder.dataFetcher(coordinates, FieldResolverDirectiveDataFetcher.from(dataFetcherContext)
-        );
+        builder.dataFetcher(coordinates, new FieldResolverDirectiveDataFetcher(dataFetcherContext));
       }
     });
     return builder;

--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextToGraphQLJavaVisitor.java
@@ -31,6 +31,7 @@ import com.intuit.graphql.graphQL.util.GraphQLSwitch;
 import com.intuit.graphql.orchestrator.datafetcher.AliasablePropertyDataFetcher;
 import com.intuit.graphql.orchestrator.schema.SchemaParseException;
 import com.intuit.graphql.orchestrator.schema.transform.ExplicitTypeResolver;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import graphql.Scalars;
 import graphql.introspection.Introspection.DirectiveLocation;
 import graphql.schema.GraphQLArgument;

--- a/src/test/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphqlErrorBuilder;
@@ -88,7 +89,8 @@ public class ResolverArgumentDataFetcherTest {
   public void testBuilder() {
     ResolverArgumentDataFetcher.newBuilder()
         .queriesByResolverArgument(Collections.emptyMap())
-        .namespace("").build();
+        .dataFetcherContext(DataFetcherContext.newBuilder().build())
+        .build();
   }
 
   @Test(expected = NullPointerException.class)
@@ -98,9 +100,8 @@ public class ResolverArgumentDataFetcherTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testBuilderNamespaceIsNull() {
-    ResolverArgumentDataFetcher.newBuilder()
-        .namespace(null);
+  public void testBuilderDataFetcherContextIsNull() {
+    ResolverArgumentDataFetcher.newBuilder().dataFetcherContext(null);
   }
 
   @Test
@@ -121,8 +122,8 @@ public class ResolverArgumentDataFetcherTest {
     map.put(debtArgumentResolver, debtQuery);
 
     ResolverArgumentDataFetcher resolverArgumentDataFetcher = ResolverArgumentDataFetcher.newBuilder()
-        .queriesByResolverArgument(map)
-        .namespace(namespace).build();
+        .queriesByResolverArgument(map).dataFetcherContext(DataFetcherContext.newBuilder().namespace(namespace).build())
+        .build();
 
     resolverArgumentDataFetcher.argumentResolver = mockArgumentResolver;
     resolverArgumentDataFetcher.helper = mockHelper;
@@ -158,7 +159,7 @@ public class ResolverArgumentDataFetcherTest {
     map.put(incomeArgumentResolver, incomeQuery);
 
     ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
-        .namespace(namespace)
+        .dataFetcherContext(DataFetcherContext.newBuilder().namespace(namespace).build())
         .queriesByResolverArgument(map)
         .build();
 
@@ -190,7 +191,7 @@ public class ResolverArgumentDataFetcherTest {
 
     ResolverArgumentDataFetcher resolverArgumentDataFetcher = ResolverArgumentDataFetcher.newBuilder()
         .queriesByResolverArgument(Collections.emptyMap())
-        .namespace(namespace)
+        .dataFetcherContext(DataFetcherContext.newBuilder().namespace(namespace).build())
         .build();
 
     resolverArgumentDataFetcher.argumentResolver = mockArgumentResolver;

--- a/src/test/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherTest.java
+++ b/src/test/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherTest.java
@@ -10,6 +10,7 @@ import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.TestServiceProvider;
 import com.intuit.graphql.orchestrator.batch.QueryExecutor;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import com.intuit.graphql.orchestrator.xtext.XtextGraph;
 import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
@@ -86,9 +87,10 @@ public class RestDataFetcherTest {
     TestServiceProvider testServiceProvider = TestServiceProvider.newBuilder().queryFunction(queryExecutor)
         .serviceType(ServiceType.REST).build();
     ServiceMetadata serviceMetadata = mock(XtextGraph.class);
+    DataFetcherContext dataFetcherContext = mock(DataFetcherContext.class);
     when(serviceMetadata.getServiceProvider()).thenReturn(testServiceProvider);
 
-    RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata);
+    RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata, dataFetcherContext);
 
     ((CompletableFuture<DataFetcherResult<Map<String, Object>>>) restDataFetcher.get(dataFetchingEnvironment))
         .whenComplete((dataFetcherResult, throwable) -> {


### PR DESCRIPTION
# What Changed
 Add metadata to data-fetchers
# Why
It can be used at runtime to collect metrics related to downstream services. 
Todo:

- [ ] Add tests
- [ ] Add docs