### PR TITLE
Collect field coordinates that a service owns in ServiceMetadata

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/schema/ServiceMetadata.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/ServiceMetadata.java
@@ -30,7 +30,10 @@ public interface ServiceMetadata {
 
   FieldResolverContext getFieldResolverContext(FieldCoordinates fieldCoordinates);
 
+  @Deprecated
   boolean isOwnedByEntityExtension(FieldCoordinates fieldCoordinates);
+
+  boolean isOwnedByThisService(FieldCoordinates fieldCoordinates);
 
   boolean isFederationService();
 

--- a/src/main/java/com/intuit/graphql/orchestrator/utils/XtextUtils.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/utils/XtextUtils.java
@@ -322,4 +322,11 @@ public class XtextUtils {
             .collect(Collectors.toList());
   }
 
+  public static boolean containsDirective(FieldDefinition fieldDefinition, String directiveName) {
+    return fieldDefinition.getDirectives().stream()
+        .anyMatch(directive ->
+            StringUtils.equals(directiveName, directive.getDefinition().getName())
+        );
+  }
+
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/xtext/XtextGraph.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/xtext/XtextGraph.java
@@ -1,6 +1,9 @@
 package com.intuit.graphql.orchestrator.xtext;
 
+import static java.util.Objects.requireNonNull;
+
 import com.intuit.graphql.graphQL.DirectiveDefinition;
+import com.intuit.graphql.graphQL.FieldDefinition;
 import com.intuit.graphql.graphQL.NamedType;
 import com.intuit.graphql.graphQL.ObjectTypeDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
@@ -13,9 +16,7 @@ import com.intuit.graphql.orchestrator.schema.Operation;
 import com.intuit.graphql.orchestrator.schema.TypeMetadata;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.utils.XtextTypeUtils;
-import lombok.Getter;
-import org.eclipse.xtext.resource.XtextResourceSet;
-
+import graphql.schema.FieldCoordinates;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-
-import static java.util.Objects.requireNonNull;
+import lombok.Getter;
+import org.eclipse.xtext.resource.XtextResourceSet;
 
 /**
  * Runtime graph represents the runtime elements required to build the runtime graphql schema. It also contains
@@ -41,6 +42,7 @@ public class XtextGraph {
   private final Map<String, TypeDefinition> types;
   private final Map<String, TypeMetadata> typeMetadatas;
   private final List<FieldResolverContext> fieldResolverContexts;
+  private final Map<FieldCoordinates, FieldDefinition> fieldCoordinates;
 
   private final boolean hasInterfaceOrUnion;
   private final boolean hasFieldResolverDefinition;
@@ -73,6 +75,7 @@ public class XtextGraph {
     entityExtensionMetadatas = builder.entityExtensionMetadatas;
     federationMetadataByNamespace = builder.federationMetadataByNamespace;
     renamedMetadataByNamespace = builder.renamedMetadataByNamespace;
+    fieldCoordinates = builder.fieldCoordinates;
   }
 
   /**
@@ -108,6 +111,7 @@ public class XtextGraph {
     builder.entityExtensionMetadatas = copy.entityExtensionMetadatas;
     builder.federationMetadataByNamespace = copy.federationMetadataByNamespace;
     builder.renamedMetadataByNamespace = copy.renamedMetadataByNamespace;
+    builder.fieldCoordinates = copy.fieldCoordinates;
     return builder;
   }
 
@@ -219,6 +223,7 @@ public class XtextGraph {
     private List<FieldResolverContext> fieldResolverContexts = new ArrayList<>();
     private Map<String, FederationMetadata> federationMetadataByNamespace = new HashMap<>();
     private Map<String, RenamedMetadata> renamedMetadataByNamespace = new HashMap<>();
+    private Map<FieldCoordinates, FieldDefinition> fieldCoordinates = new HashMap<>();
     private boolean hasInterfaceOrUnion = false;
     private boolean hasFieldResolverDefinition = false;
 
@@ -395,6 +400,11 @@ public class XtextGraph {
     public Builder renamedMetadataByNamespace(Map<String, RenamedMetadata> renamedMetadataByNamespace) {
       requireNonNull(renamedMetadataByNamespace);
       this.renamedMetadataByNamespace.putAll(renamedMetadataByNamespace);
+      return this;
+    }
+
+    public Builder fieldCoordinates(Map<FieldCoordinates, FieldDefinition> fieldCoordinates) {
+      this.fieldCoordinates.putAll(fieldCoordinates);
       return this;
     }
 

--- a/src/test/groovy/com/intuit/graphql/orchestrator/schema/ServiceMetadataImplSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/schema/ServiceMetadataImplSpec.groovy
@@ -1,0 +1,92 @@
+package com.intuit.graphql.orchestrator.schema
+
+import com.intuit.graphql.graphQL.Directive
+import com.intuit.graphql.graphQL.DirectiveDefinition
+import com.intuit.graphql.graphQL.FieldDefinition
+import com.intuit.graphql.orchestrator.ServiceProvider
+import com.intuit.graphql.orchestrator.utils.FederationConstants
+import graphql.schema.FieldCoordinates
+import org.eclipse.emf.common.util.BasicEList
+import spock.lang.Specification
+
+class ServiceMetadataImplSpec extends Specification {
+
+    FieldCoordinates fieldCoordinates = FieldCoordinates.coordinates("ParentType", "fieldName")
+
+    Directive externalDirectiveMock
+    FieldDefinition fieldDefinitionWithExternalDirectiveMock
+    FieldDefinition basicFieldDefinitionMock
+    ServiceProvider serviceProviderMock
+
+    void setup() {
+        def externalDirectiveDefinitionMock = Mock(DirectiveDefinition.class)
+        externalDirectiveDefinitionMock.getName() >> FederationConstants.FEDERATION_EXTERNAL_DIRECTIVE
+
+        serviceProviderMock = Mock(ServiceProvider.class)
+        serviceProviderMock.isFederationProvider() >> false
+        externalDirectiveMock = Mock(Directive.class)
+        externalDirectiveMock.getDefinition() >> externalDirectiveDefinitionMock
+        fieldDefinitionWithExternalDirectiveMock = Mock(FieldDefinition.class)
+        fieldDefinitionWithExternalDirectiveMock.getDirectives() >> new BasicEList<Directive>([externalDirectiveMock])
+
+        basicFieldDefinitionMock = Mock(FieldDefinition.class);
+        basicFieldDefinitionMock.getDirectives() >> new BasicEList<Directive>()
+    }
+
+    def "isOwnedByThisService() tests a field with @external returns false"() {
+        given:
+        ServiceMetadata specUnderTest = ServiceMetadataImpl.newBuilder()
+                .fieldCoordinates([(fieldCoordinates): fieldDefinitionWithExternalDirectiveMock])
+                .serviceProvider(serviceProviderMock)
+                .build()
+
+        when:
+        def actual = specUnderTest.isOwnedByThisService(fieldCoordinates)
+
+        then:
+        actual == false
+    }
+
+    def "isOwnedByThisService() tests a field without directives returns true"() {
+        given:
+        ServiceMetadata specUnderTest = ServiceMetadataImpl.newBuilder()
+                .fieldCoordinates([(fieldCoordinates): basicFieldDefinitionMock])
+                .serviceProvider(serviceProviderMock)
+                .build()
+
+        when:
+        def actual = specUnderTest.isOwnedByThisService(fieldCoordinates)
+
+        then:
+        actual == true
+    }
+
+    def "isOwnedByThisService() tests a field not in fieldCoordinates map"() {
+        given:
+        ServiceMetadata specUnderTest = ServiceMetadataImpl.newBuilder()
+                .fieldCoordinates(Collections.emptyMap())
+                .serviceProvider(serviceProviderMock)
+                .build()
+
+        when:
+        def actual = specUnderTest.isOwnedByThisService(fieldCoordinates)
+
+        then:
+        actual == false
+    }
+
+    def "isOwnedByThisService() tests a field with null fieldCoordinates map"() {
+        given:
+        ServiceMetadata specUnderTest = ServiceMetadataImpl.newBuilder()
+                .fieldCoordinates(null)
+                .serviceProvider(serviceProviderMock)
+                .build()
+
+        when:
+        def actual = specUnderTest.isOwnedByThisService(fieldCoordinates)
+
+        then:
+        actual == false
+    }
+
+}

--- a/src/test/groovy/com/intuit/graphql/orchestrator/schema/transform/AllTypesTransformerSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/schema/transform/AllTypesTransformerSpec.groovy
@@ -31,6 +31,7 @@ class AllTypesTransformerSpec extends Specification {
         transformed.getTypes().containsKey("QueryType") == false
         transformed.getTypes().size() == 3
         transformed.getTypeMetadatas().size() == 3
+        transformed.getFieldCoordinates().size() == 5
     }
 
     void "test Throws Exception On Duplicate Type Definition"() {


### PR DESCRIPTION
# What Changed
- ServiceMetadata new method `isOwnedByThisService(FieldCoordinates fieldCoordinates)`
- ServiceMetadataImpl maintains a map of FieldCoordinate -> FieldDefinition that a service owns

# Why

Todo:

- [x] Add tests
- [ ] Add docs