### PR TITLE
Adding DataFetcherType in ServiceAwareDataFetcher 

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherType.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherType.java
@@ -1,9 +1,0 @@
-package com.intuit.graphql.orchestrator.datafetcher;
-
-public enum DataFetcherType {
-  SERVICE_DATA_FETCHER,
-  FEDERATION_SERVICE_DATA_FETCHER,
-  ENTITY_DATA_FETCHER,
-  FIELD_RESOLVER_DATA_FETCHER,
-  RESOLVER_ARGUMENT_DATA_FETCHER, REST_DATA_FETCHER
-}

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherType.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/DataFetcherType.java
@@ -1,0 +1,9 @@
+package com.intuit.graphql.orchestrator.datafetcher;
+
+public enum DataFetcherType {
+  SERVICE_DATA_FETCHER,
+  FEDERATION_SERVICE_DATA_FETCHER,
+  ENTITY_DATA_FETCHER,
+  FIELD_RESOLVER_DATA_FETCHER,
+  RESOLVER_ARGUMENT_DATA_FETCHER, REST_DATA_FETCHER
+}

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
@@ -13,11 +14,13 @@ public class FieldResolverDirectiveDataFetcher implements ServiceAwareDataFetche
 
   private final FieldResolverContext fieldResolverContext;
   private final String namespace;
+  private final ServiceType serviceType;
 
   private FieldResolverDirectiveDataFetcher(FieldResolverContext fieldResolverContext,
-      String namespace) {
+      String namespace, ServiceType serviceType) {
     this.fieldResolverContext = fieldResolverContext;
     this.namespace = namespace;
+    this.serviceType = serviceType;
   }
 
   public static FieldResolverDirectiveDataFetcher from(DataFetcherContext dataFetcherContext) {
@@ -25,7 +28,7 @@ public class FieldResolverDirectiveDataFetcher implements ServiceAwareDataFetche
     Objects.requireNonNull(dataFetcherContext.getFieldResolverContext(),
         "FieldResolverContext is required");
     return new FieldResolverDirectiveDataFetcher(dataFetcherContext.getFieldResolverContext(),
-        dataFetcherContext.getNamespace());
+        dataFetcherContext.getNamespace(), dataFetcherContext.getServiceType());
   }
 
   @Override

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
@@ -3,6 +3,7 @@ package com.intuit.graphql.orchestrator.datafetcher;
 import com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Objects;
 import lombok.Getter;
@@ -36,6 +37,6 @@ public class FieldResolverDirectiveDataFetcher implements ServiceAwareDataFetche
 
   @Override
   public DataFetcherType getDataFetcherType() {
-    return DataFetcherType.FIELD_RESOLVER_DATA_FETCHER;
+    return DataFetcherType.RESOLVER_ON_FIELD_DEFINITION;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcher.java
@@ -3,7 +3,6 @@ package com.intuit.graphql.orchestrator.datafetcher;
 import com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil;
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Objects;
 import lombok.Getter;
@@ -35,4 +34,8 @@ public class FieldResolverDirectiveDataFetcher implements ServiceAwareDataFetche
         .load(dataFetchingEnvironment);
   }
 
+  @Override
+  public DataFetcherType getDataFetcherType() {
+    return DataFetcherType.FIELD_RESOLVER_DATA_FETCHER;
+  }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.ExecutionResult;
@@ -29,6 +30,7 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
 
   private final String namespace;
   private final Map<ResolverArgumentDirective, OperationDefinition> resolverQueryByDirective;
+  private final ServiceType serviceType;
 
   @VisibleForTesting
   ResolverArgumentDataFetcherHelper helper;
@@ -39,6 +41,7 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
   private ResolverArgumentDataFetcher(final Builder builder) {
     resolverQueryByDirective = builder.resolverQueryByDirective;
     namespace = builder.namespace;
+    serviceType = builder.serviceType;
     this.helper = new ResolverArgumentDataFetcherHelper(namespace);
     this.argumentResolver = ArgumentResolver.newBuilder().build();
   }
@@ -120,10 +123,16 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
     return DataFetcherType.RESOLVER_ARGUMENT;
   }
 
+  @Override
+  public ServiceType getServiceType() {
+    return this.serviceType;
+  }
+
   public static final class Builder {
 
     private Map<ResolverArgumentDirective, OperationDefinition> resolverQueryByDirective = new HashMap<>();
     private String namespace;
+    private ServiceType serviceType;
 
     private Builder() {
     }
@@ -135,6 +144,11 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
 
     public Builder namespace(final String val) {
       namespace = Objects.requireNonNull(val);
+      return this;
+    }
+
+    public Builder serviceType(final ServiceType serviceType) {
+      this. serviceType = serviceType;
       return this;
     }
 

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
@@ -1,6 +1,7 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
 import graphql.VisibleForTesting;
@@ -116,7 +117,7 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
 
   @Override
   public DataFetcherType getDataFetcherType() {
-    return DataFetcherType.RESOLVER_ARGUMENT_DATA_FETCHER;
+    return DataFetcherType.RESOLVER_ARGUMENT;
   }
 
   public static final class Builder {

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcher.java
@@ -7,7 +7,6 @@ import graphql.VisibleForTesting;
 import graphql.execution.Async;
 import graphql.execution.DataFetcherResult;
 import graphql.language.OperationDefinition;
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -113,6 +112,11 @@ public class ResolverArgumentDataFetcher implements ServiceAwareDataFetcher<Comp
     }
 
     return retVal;
+  }
+
+  @Override
+  public DataFetcherType getDataFetcherType() {
+    return DataFetcherType.RESOLVER_ARGUMENT_DATA_FETCHER;
   }
 
   public static final class Builder {

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
@@ -13,7 +13,6 @@ import graphql.language.OperationDefinition;
 import graphql.language.OperationDefinition.Operation;
 import graphql.language.SelectionSet;
 import graphql.language.VariableDefinition;
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import lombok.Getter;
@@ -75,5 +74,10 @@ public class RestDataFetcher implements ServiceAwareDataFetcher {
   @Override
   public String getNamespace() {
     return this.serviceMetadata.getServiceProvider().getNameSpace();
+  }
+
+  @Override
+  public DataFetcherType getDataFetcherType() {
+    return DataFetcherType.REST_DATA_FETCHER;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
@@ -3,6 +3,7 @@ package com.intuit.graphql.orchestrator.datafetcher;
 import static com.intuit.graphql.orchestrator.batch.DefaultBatchResultTransformer.toSingleResult;
 import static graphql.language.AstPrinter.printAstCompact;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.batch.DefaultQueryResponseModifier;
 import com.intuit.graphql.orchestrator.batch.QueryResponseModifier;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
@@ -19,7 +20,7 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class RestDataFetcher implements ServiceAwareDataFetcher {
+public class RestDataFetcher implements ServiceAwareDataFetcher<Object> {
 
   private final ServiceMetadata serviceMetadata;
   private final QueryResponseModifier queryResponseModifier = new DefaultQueryResponseModifier();
@@ -80,5 +81,10 @@ public class RestDataFetcher implements ServiceAwareDataFetcher {
   @Override
   public DataFetcherType getDataFetcherType() {
     return DataFetcherType.REST;
+  }
+
+  @Override
+  public ServiceType getServiceType() {
+    return this.serviceMetadata.getServiceProvider().getSeviceType();
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcher.java
@@ -6,6 +6,7 @@ import static graphql.language.AstPrinter.printAstCompact;
 import com.intuit.graphql.orchestrator.batch.DefaultQueryResponseModifier;
 import com.intuit.graphql.orchestrator.batch.QueryResponseModifier;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
 import graphql.language.Document;
@@ -78,6 +79,6 @@ public class RestDataFetcher implements ServiceAwareDataFetcher {
 
   @Override
   public DataFetcherType getDataFetcherType() {
-    return DataFetcherType.REST_DATA_FETCHER;
+    return DataFetcherType.REST;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.schema.DataFetcher;
 
 public interface ServiceAwareDataFetcher<T> extends DataFetcher<T> {

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
@@ -1,9 +1,11 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.schema.DataFetcher;
 
 public interface ServiceAwareDataFetcher<T> extends DataFetcher<T> {
   String getNamespace();
   DataFetcherType getDataFetcherType();
+  ServiceType getServiceType();
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceAwareDataFetcher.java
@@ -4,4 +4,5 @@ import graphql.schema.DataFetcher;
 
 public interface ServiceAwareDataFetcher<T> extends DataFetcher<T> {
   String getNamespace();
+  DataFetcherType getDataFetcherType();
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.GraphQLContext;
@@ -39,5 +40,10 @@ public class ServiceDataFetcher implements ServiceAwareDataFetcher {
   @Override
   public DataFetcherType getDataFetcherType() {
     return DataFetcherType.SERVICE;
+  }
+
+  @Override
+  public ServiceType getServiceType() {
+    return this.serviceMetadata.getServiceProvider().getSeviceType();
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
@@ -1,11 +1,11 @@
 package com.intuit.graphql.orchestrator.datafetcher;
 
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
-import lombok.Getter;
-
 import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
 
 @Getter
 public class ServiceDataFetcher implements ServiceAwareDataFetcher {
@@ -38,6 +38,6 @@ public class ServiceDataFetcher implements ServiceAwareDataFetcher {
 
   @Override
   public DataFetcherType getDataFetcherType() {
-    return DataFetcherType.SERVICE_DATA_FETCHER;
+    return DataFetcherType.SERVICE;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcher.java
@@ -35,4 +35,9 @@ public class ServiceDataFetcher implements ServiceAwareDataFetcher {
   public String getNamespace() {
     return this.serviceMetadata.getServiceProvider().getNameSpace();
   }
+
+  @Override
+  public DataFetcherType getDataFetcherType() {
+    return DataFetcherType.SERVICE_DATA_FETCHER;
+  }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
@@ -1,20 +1,21 @@
 package com.intuit.graphql.orchestrator.federation;
 
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import lombok.RequiredArgsConstructor;
-
-import java.util.concurrent.CompletableFuture;
-
 import static com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil.createDataLoaderKey;
+
+import com.intuit.graphql.orchestrator.datafetcher.DataFetcherType;
+import com.intuit.graphql.orchestrator.datafetcher.ServiceAwareDataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
 
 /**
  * This class is used for resolving fields added to an Entity by making an entity fetch request. To
  * build the entity fetch query, it uses {@link EntityQuery}.
  */
 @RequiredArgsConstructor
-public class EntityDataFetcher implements DataFetcher<CompletableFuture<Object>> {
+public class EntityDataFetcher implements ServiceAwareDataFetcher<CompletableFuture<Object>> {
   private final String entityName;
+  private final String namespace;
 
   @Override
   public CompletableFuture<Object> get(final DataFetchingEnvironment dataFetchingEnvironment) {
@@ -23,5 +24,15 @@ public class EntityDataFetcher implements DataFetcher<CompletableFuture<Object>>
     return dataFetchingEnvironment
             .getDataLoader(batchLoaderKey)
             .load(dataFetchingEnvironment);
+  }
+
+  @Override
+  public String getNamespace() {
+    return this.namespace;
+  }
+
+  @Override
+  public DataFetcherType getDataFetcherType() {
+    return DataFetcherType.ENTITY_DATA_FETCHER;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
@@ -2,6 +2,7 @@ package com.intuit.graphql.orchestrator.federation;
 
 import static com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil.createDataLoaderKey;
 
+import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType;
 import com.intuit.graphql.orchestrator.datafetcher.ServiceAwareDataFetcher;
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.schema.DataFetchingEnvironment;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class EntityDataFetcher implements ServiceAwareDataFetcher<CompletableFuture<Object>> {
   private final String entityName;
   private final String namespace;
+  private final ServiceType serviceType;
 
   @Override
   public CompletableFuture<Object> get(final DataFetchingEnvironment dataFetchingEnvironment) {
@@ -34,5 +36,10 @@ public class EntityDataFetcher implements ServiceAwareDataFetcher<CompletableFut
   @Override
   public DataFetcherType getDataFetcherType() {
     return DataFetcherType.ENTITY_FETCHER;
+  }
+
+  @Override
+  public ServiceType getServiceType() {
+    return this.serviceType;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/federation/EntityDataFetcher.java
@@ -2,8 +2,8 @@ package com.intuit.graphql.orchestrator.federation;
 
 import static com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil.createDataLoaderKey;
 
-import com.intuit.graphql.orchestrator.datafetcher.DataFetcherType;
 import com.intuit.graphql.orchestrator.datafetcher.ServiceAwareDataFetcher;
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +33,6 @@ public class EntityDataFetcher implements ServiceAwareDataFetcher<CompletableFut
 
   @Override
   public DataFetcherType getDataFetcherType() {
-    return DataFetcherType.ENTITY_DATA_FETCHER;
+    return DataFetcherType.ENTITY_FETCHER;
   }
 }

--- a/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FederationTransformerPostMerge.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/schema/transform/FederationTransformerPostMerge.java
@@ -1,5 +1,20 @@
 package com.intuit.graphql.orchestrator.schema.transform;
 
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_DIRECTIVE_NAME;
+import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_EXTENDS_DIRECTIVE;
+import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_EXTERNAL_DIRECTIVE;
+import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_INACCESSIBLE_DIRECTIVE;
+import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_KEY_DIRECTIVE;
+import static com.intuit.graphql.orchestrator.utils.FederationUtils.isTypeSystemForBaseType;
+import static com.intuit.graphql.orchestrator.utils.XtextGraphUtils.addToCodeRegistry;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isInterfaceTypeDefinition;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isInterfaceTypeExtensionDefinition;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isObjectTypeDefinition;
+import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isObjectTypeExtensionDefinition;
+import static com.intuit.graphql.orchestrator.utils.XtextUtils.definitionContainsDirective;
+import static java.lang.String.format;
+
 import com.intuit.graphql.graphQL.Directive;
 import com.intuit.graphql.graphQL.FieldDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
@@ -17,8 +32,6 @@ import com.intuit.graphql.orchestrator.schema.type.conflict.resolver.TypeConflic
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext;
 import com.intuit.graphql.orchestrator.xtext.FieldContext;
 import com.intuit.graphql.orchestrator.xtext.UnifiedXtextGraph;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -26,21 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_EXTENDS_DIRECTIVE;
-import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_DIRECTIVE_NAME;
-import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_EXTERNAL_DIRECTIVE;
-import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_INACCESSIBLE_DIRECTIVE;
-import static com.intuit.graphql.orchestrator.utils.FederationConstants.FEDERATION_KEY_DIRECTIVE;
-import static com.intuit.graphql.orchestrator.utils.FederationUtils.isTypeSystemForBaseType;
-import static com.intuit.graphql.orchestrator.utils.XtextGraphUtils.addToCodeRegistry;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.getFieldDefinitions;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isInterfaceTypeDefinition;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isInterfaceTypeExtensionDefinition;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isObjectTypeDefinition;
-import static com.intuit.graphql.orchestrator.utils.XtextTypeUtils.isObjectTypeExtensionDefinition;
-import static com.intuit.graphql.orchestrator.utils.XtextUtils.definitionContainsDirective;
-import static java.lang.String.format;
+import org.apache.commons.lang3.StringUtils;
 
 public class FederationTransformerPostMerge implements Transformer<UnifiedXtextGraph, UnifiedXtextGraph> {
 
@@ -76,6 +75,7 @@ public class FederationTransformerPostMerge implements Transformer<UnifiedXtextG
               FieldContext fieldContext = new FieldContext(entityExtensionMetadata.getTypeName(), fieldName);
               DataFetcherContext dataFetcherContext = DataFetcherContext
                       .newBuilder()
+                      .namespace(entityExtensionMetadata.getFederationMetadata().getServiceProvider().getNameSpace())
                       .dataFetcherType(DataFetcherContext.DataFetcherType.ENTITY_FETCHER)
                       .entityExtensionMetadata(entityExtensionMetadata)
                       .build();

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
@@ -1,5 +1,17 @@
 package com.intuit.graphql.orchestrator.stitching;
 
+import static com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil.createDataLoaderKey;
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_ARGUMENT_INPUT_NAME;
+import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_DIRECTIVE_NAME;
+import static com.intuit.graphql.orchestrator.utils.XtextUtils.getAllTypes;
+import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.ENTITY_FETCHER;
+import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.RESOLVER_ARGUMENT;
+import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.RESOLVER_ON_FIELD_DEFINITION;
+import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.SERVICE;
+import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.STATIC;
+import static graphql.schema.FieldCoordinates.coordinates;
+import static java.util.Objects.requireNonNull;
+
 import com.intuit.graphql.graphQL.ObjectTypeDefinition;
 import com.intuit.graphql.graphQL.TypeDefinition;
 import com.intuit.graphql.orchestrator.ServiceProvider;
@@ -49,8 +61,6 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
 import graphql.schema.StaticDataFetcher;
-import org.dataloader.BatchLoader;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -60,18 +70,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static com.intuit.graphql.orchestrator.batch.DataLoaderKeyUtil.createDataLoaderKey;
-import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_ARGUMENT_INPUT_NAME;
-import static com.intuit.graphql.orchestrator.resolverdirective.FieldResolverDirectiveUtil.RESOLVER_DIRECTIVE_NAME;
-import static com.intuit.graphql.orchestrator.utils.XtextUtils.getAllTypes;
-import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.ENTITY_FETCHER;
-import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.RESOLVER_ARGUMENT;
-import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.RESOLVER_ON_FIELD_DEFINITION;
-import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.SERVICE;
-import static com.intuit.graphql.orchestrator.xtext.DataFetcherContext.DataFetcherType.STATIC;
-import static graphql.schema.FieldCoordinates.coordinates;
-import static java.util.Objects.requireNonNull;
+import org.dataloader.BatchLoader;
 
 /**
  * The type Xtext stitcher.
@@ -269,7 +268,7 @@ public class XtextStitcher implements Stitcher {
         builder.dataFetcher(coordinates, FieldResolverDirectiveDataFetcher.from(dataFetcherContext)
         );
       } else if (type == ENTITY_FETCHER && mergedGraph.getType(fieldContext.getParentType()) != null) {
-        builder.dataFetcher(coordinates, new EntityDataFetcher(dataFetcherContext.getEntityExtensionMetadata().getTypeName())
+        builder.dataFetcher(coordinates, new EntityDataFetcher(dataFetcherContext.getEntityExtensionMetadata().getTypeName(), dataFetcherContext.getNamespace())
         );
       }
     });

--- a/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/stitching/XtextStitcher.java
@@ -262,14 +262,16 @@ public class XtextStitcher implements Stitcher {
         builder.dataFetcher(coordinates, ResolverArgumentDataFetcher.newBuilder()
             .namespace(dataFetcherContext.getNamespace())
             .queriesByResolverArgument(map)
+            .serviceType(dataFetcherContext.getServiceType())
             .build()
         );
       } else if (type == RESOLVER_ON_FIELD_DEFINITION) {
         builder.dataFetcher(coordinates, FieldResolverDirectiveDataFetcher.from(dataFetcherContext)
         );
       } else if (type == ENTITY_FETCHER && mergedGraph.getType(fieldContext.getParentType()) != null) {
-        builder.dataFetcher(coordinates, new EntityDataFetcher(dataFetcherContext.getEntityExtensionMetadata().getTypeName(), dataFetcherContext.getNamespace())
-        );
+        EntityDataFetcher entityDataFetcher = new EntityDataFetcher(dataFetcherContext.getEntityExtensionMetadata().getTypeName(),
+          dataFetcherContext.getNamespace(), dataFetcherContext.getServiceType());
+        builder.dataFetcher(coordinates, entityDataFetcher);
       }
     });
     return builder;

--- a/src/main/java/com/intuit/graphql/orchestrator/xtext/DataFetcherContext.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/xtext/DataFetcherContext.java
@@ -39,7 +39,7 @@ public class DataFetcherContext {
   }
 
   public enum DataFetcherType {
-    STATIC, SERVICE, PROPERTY, RESOLVER_ARGUMENT, RESOLVER_ON_FIELD_DEFINITION, ENTITY_FETCHER;
+    STATIC, SERVICE, PROPERTY, RESOLVER_ARGUMENT, RESOLVER_ON_FIELD_DEFINITION, ENTITY_FETCHER, REST
   }
 
   public static final class Builder {

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
@@ -1,0 +1,33 @@
+package com.intuit.graphql.orchestrator.datafetcher
+
+
+import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext
+import spock.lang.Specification
+
+class FieldResolverDirectiveDataFetcherSpec extends Specification {
+
+    def "returns correct namespace"() {
+        given:
+        FieldResolverContext fieldResolverContext = Mock(FieldResolverContext.class)
+        FieldResolverDirectiveDataFetcher dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace")
+
+        when:
+        String actualNamespace = dataFetcher.getNamespace()
+
+        then:
+        actualNamespace == "TestNamespace"
+    }
+
+    def "returns correct DataFetcherType"() {
+        given:
+       FieldResolverContext fieldResolverContext = Mock(FieldResolverContext.class)
+        FieldResolverDirectiveDataFetcher dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace")
+
+        when:
+        DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
+
+        then:
+        actualDataFetcherType == DataFetcherType.FIELD_RESOLVER_DATA_FETCHER
+    }
+
+}

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
@@ -2,6 +2,7 @@ package com.intuit.graphql.orchestrator.datafetcher
 
 
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import spock.lang.Specification
 
 class FieldResolverDirectiveDataFetcherSpec extends Specification {
@@ -24,10 +25,10 @@ class FieldResolverDirectiveDataFetcherSpec extends Specification {
         FieldResolverDirectiveDataFetcher dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace")
 
         when:
-        DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
+        DataFetcherContext.DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
 
         then:
-        actualDataFetcherType == DataFetcherType.FIELD_RESOLVER_DATA_FETCHER
+        actualDataFetcherType == DataFetcherContext.DataFetcherType.RESOLVER_ON_FIELD_DEFINITION
     }
 
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/FieldResolverDirectiveDataFetcherSpec.groovy
@@ -1,17 +1,20 @@
 package com.intuit.graphql.orchestrator.datafetcher
 
-
+import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.schema.transform.FieldResolverContext
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import spock.lang.Specification
 
 class FieldResolverDirectiveDataFetcherSpec extends Specification {
 
-    def "returns correct namespace"() {
-        given:
-        FieldResolverContext fieldResolverContext = Mock(FieldResolverContext.class)
-        FieldResolverDirectiveDataFetcher dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace")
+    FieldResolverDirectiveDataFetcher dataFetcher
 
+    def setup() {
+        FieldResolverContext fieldResolverContext = Mock(FieldResolverContext.class)
+        dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace", ServiceProvider.ServiceType.GRAPHQL)
+    }
+
+    def "returns correct namespace"() {
         when:
         String actualNamespace = dataFetcher.getNamespace()
 
@@ -20,15 +23,19 @@ class FieldResolverDirectiveDataFetcherSpec extends Specification {
     }
 
     def "returns correct DataFetcherType"() {
-        given:
-       FieldResolverContext fieldResolverContext = Mock(FieldResolverContext.class)
-        FieldResolverDirectiveDataFetcher dataFetcher = new FieldResolverDirectiveDataFetcher(fieldResolverContext, "TestNamespace")
-
         when:
         DataFetcherContext.DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
 
         then:
         actualDataFetcherType == DataFetcherContext.DataFetcherType.RESOLVER_ON_FIELD_DEFINITION
+    }
+
+    def "returns correct ServiceType"() {
+        when:
+        ServiceProvider.ServiceType actualServiceType = dataFetcher.getServiceType()
+
+        then:
+        actualServiceType == ServiceProvider.ServiceType.GRAPHQL
     }
 
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
@@ -1,7 +1,7 @@
 package com.intuit.graphql.orchestrator.datafetcher
 
-import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective
 import com.intuit.graphql.orchestrator.TestHelper
+import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective
 import graphql.ExecutionResult
 import graphql.ExecutionResultImpl
 import graphql.GraphqlErrorBuilder
@@ -16,7 +16,6 @@ import org.dataloader.DataLoader
 import org.dataloader.DataLoaderRegistry
 
 import java.util.concurrent.CompletableFuture
-
 
 class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
 
@@ -198,5 +197,33 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
 
         then:
         result.getErrors().size() == 1
+    }
+
+    def "returns correct namespace"() {
+        given:
+        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
+                .queriesByResolverArgument(Collections.emptyMap())
+                .namespace(namespace)
+                .build()
+
+        when:
+        String actualNamespace = dataFetcher.getNamespace()
+
+        then:
+        actualNamespace == namespace
+    }
+
+    def "returns correct DataFetcherType"() {
+        given:
+        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
+                .queriesByResolverArgument(Collections.emptyMap())
+                .namespace(namespace)
+                .build()
+
+        when:
+        DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
+
+        then:
+        actualDataFetcherType == DataFetcherType.RESOLVER_ARGUMENT_DATA_FETCHER
     }
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.datafetcher
 
+import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.TestHelper
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
@@ -59,6 +60,12 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
 
     private DataLoaderRegistry dataLoaderRegistry
 
+    ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
+        .queriesByResolverArgument(Collections.emptyMap())
+        .namespace(namespace)
+        .serviceType(ServiceProvider.ServiceType.GRAPHQL)
+        .build()
+
     def setup() {
         mockHelper = Mock(ResolverArgumentDataFetcherHelper.class)
         mockArgumentResolver = Mock(ArgumentResolver.class)
@@ -117,19 +124,19 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
 
         map.put(debtArgumentResolver, debtQuery)
 
-        ResolverArgumentDataFetcher resolverArgumentDataFetcher = ResolverArgumentDataFetcher.newBuilder()
+        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
                 .queriesByResolverArgument(map)
                 .namespace(namespace).build()
 
-        resolverArgumentDataFetcher.argumentResolver = mockArgumentResolver
-        resolverArgumentDataFetcher.helper = mockHelper
+        dataFetcher.argumentResolver = mockArgumentResolver
+        dataFetcher.helper = mockHelper
 
         DataFetchingEnvironment dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
                 .dataLoaderRegistry(dataLoaderRegistry)
                 .build()
 
         when:
-        final DataFetcherResult<Object> result = resolverArgumentDataFetcher
+        final DataFetcherResult<Object> result = dataFetcher
                 .get(dataFetchingEnvironment).join()
 
         then:
@@ -156,7 +163,7 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
         map.put(debtArgumentResolver, debtQuery)
         map.put(incomeArgumentResolver, incomeQuery)
 
-        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
+        dataFetcher = ResolverArgumentDataFetcher.newBuilder()
                 .queriesByResolverArgument(map)
                 .namespace(namespace).build()
 
@@ -185,15 +192,10 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
 
         mockArgumentResolver.resolveArguments(_ as DataFetchingEnvironment, _ as Map) >> resolvedArguments
 
-        ResolverArgumentDataFetcher resolverArgumentDataFetcher = ResolverArgumentDataFetcher.newBuilder()
-                .queriesByResolverArgument(Collections.emptyMap())
-                .namespace(namespace)
-                .build()
-
-        resolverArgumentDataFetcher.argumentResolver = mockArgumentResolver
+        dataFetcher.argumentResolver = mockArgumentResolver
 
         when:
-        final DataFetcherResult<Object> result = resolverArgumentDataFetcher
+        final DataFetcherResult<Object> result = dataFetcher
                 .get(Mock(DataFetchingEnvironment.class)).join()
 
         then:
@@ -201,12 +203,6 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
     }
 
     def "returns correct namespace"() {
-        given:
-        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
-                .queriesByResolverArgument(Collections.emptyMap())
-                .namespace(namespace)
-                .build()
-
         when:
         String actualNamespace = dataFetcher.getNamespace()
 
@@ -215,12 +211,6 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
     }
 
     def "returns correct DataFetcherType"() {
-        given:
-        ResolverArgumentDataFetcher dataFetcher = ResolverArgumentDataFetcher.newBuilder()
-                .queriesByResolverArgument(Collections.emptyMap())
-                .namespace(namespace)
-                .build()
-
         when:
         DataFetcherContext.DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
 

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ResolverArgumentDataFetcherSpec.groovy
@@ -2,6 +2,7 @@ package com.intuit.graphql.orchestrator.datafetcher
 
 import com.intuit.graphql.orchestrator.TestHelper
 import com.intuit.graphql.orchestrator.resolverdirective.ResolverArgumentDirective
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import graphql.ExecutionResult
 import graphql.ExecutionResultImpl
 import graphql.GraphqlErrorBuilder
@@ -221,9 +222,9 @@ class ResolverArgumentDataFetcherSpec extends BaseIntegrationTestSpecification {
                 .build()
 
         when:
-        DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
+        DataFetcherContext.DataFetcherType actualDataFetcherType = dataFetcher.getDataFetcherType()
 
         then:
-        actualDataFetcherType == DataFetcherType.RESOLVER_ARGUMENT_DATA_FETCHER
+        actualDataFetcherType == DataFetcherContext.DataFetcherType.RESOLVER_ARGUMENT
     }
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
@@ -1,6 +1,7 @@
 package com.intuit.graphql.orchestrator.datafetcher
 
 import com.google.common.collect.ImmutableMap
+import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.ServiceProvider.ServiceType
 import com.intuit.graphql.orchestrator.TestServiceProvider
 import com.intuit.graphql.orchestrator.batch.QueryExecutor
@@ -99,9 +100,34 @@ class RestDataFetcherSpec extends Specification {
         noExceptionThrown()
     }
 
-    // TODO see if needed
-    // public void canExecuteRequestWithEmptySelectionSet() {
-    // }
+    def "returns correct namespace"() {
+        given:
+        ServiceProvider serviceProvider = Mock(ServiceProvider.class)
+        serviceProvider.getNameSpace() >> "TestNamespace"
+
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+        serviceMetadata.getServiceProvider() >> serviceProvider
+
+        RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata)
+
+        when:
+        String actualNamespace = restDataFetcher.getNamespace()
+
+        then:
+        actualNamespace == "TestNamespace"
+    }
+
+    def "returns correct DataFetcherType"() {
+        given:
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+        RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata)
+
+        when:
+        DataFetcherType actualDataFetcherType = restDataFetcher.getDataFetcherType()
+
+        then:
+        actualDataFetcherType == DataFetcherType.REST_DATA_FETCHER
+    }
 
     private DataFetchingEnvironment createTestDataFetchingEnvironment(
             OperationDefinition opDef, MergedField field, Map<String, Object> variables) {

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
@@ -130,6 +130,23 @@ class RestDataFetcherSpec extends Specification {
         actualDataFetcherType == DataFetcherContext.DataFetcherType.REST
     }
 
+    def "returns correct ServiceType"() {
+        given:
+        ServiceProvider serviceProvider = Mock(ServiceProvider.class)
+        serviceProvider.getSeviceType() >> ServiceType.REST
+
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+        serviceMetadata.getServiceProvider() >> serviceProvider
+
+        RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata)
+
+        when:
+        ServiceType actualServiceType = restDataFetcher.getServiceType()
+
+        then:
+        actualServiceType == ServiceType.REST
+    }
+
     private DataFetchingEnvironment createTestDataFetchingEnvironment(
             OperationDefinition opDef, MergedField field, Map<String, Object> variables) {
         return newDataFetchingEnvironment()

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/RestDataFetcherSpec.groovy
@@ -7,6 +7,7 @@ import com.intuit.graphql.orchestrator.TestServiceProvider
 import com.intuit.graphql.orchestrator.batch.QueryExecutor
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata
 import com.intuit.graphql.orchestrator.schema.ServiceMetadataImpl
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import graphql.GraphQLContext
 import graphql.execution.DataFetcherResult
 import graphql.execution.MergedField
@@ -123,10 +124,10 @@ class RestDataFetcherSpec extends Specification {
         RestDataFetcher restDataFetcher = new RestDataFetcher(serviceMetadata)
 
         when:
-        DataFetcherType actualDataFetcherType = restDataFetcher.getDataFetcherType()
+        DataFetcherContext.DataFetcherType actualDataFetcherType = restDataFetcher.getDataFetcherType()
 
         then:
-        actualDataFetcherType == DataFetcherType.REST_DATA_FETCHER
+        actualDataFetcherType == DataFetcherContext.DataFetcherType.REST
     }
 
     private DataFetchingEnvironment createTestDataFetchingEnvironment(

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
@@ -68,4 +68,34 @@ class ServiceDataFetcherSpec extends Specification {
         ((CompletableFuture) mresult).getNow("fail") == "mresult"
     }
 
+    def "returns correct namespace"() {
+        given:
+        ServiceProvider serviceProvider = Mock(ServiceProvider.class)
+        serviceProvider.getNameSpace() >> "TestNamespace"
+
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+        serviceMetadata.getServiceProvider() >> serviceProvider
+
+        ServiceDataFetcher serviceDataFetcher = new ServiceDataFetcher(serviceMetadata)
+
+        when:
+        String actualNamespace = serviceDataFetcher.getNamespace()
+
+        then:
+        actualNamespace == "TestNamespace"
+    }
+
+    def "returns correct DataFetcherType"() {
+        given:
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+
+        ServiceDataFetcher serviceDataFetcher = new ServiceDataFetcher(serviceMetadata)
+
+        when:
+        DataFetcherType actualDataFetcherType = serviceDataFetcher.getDataFetcherType()
+
+        then:
+        actualDataFetcherType == DataFetcherType.SERVICE_DATA_FETCHER
+    }
+
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
@@ -4,6 +4,7 @@ import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.TestServiceProvider
 import com.intuit.graphql.orchestrator.schema.ServiceMetadata
 import com.intuit.graphql.orchestrator.schema.ServiceMetadataImpl
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import graphql.GraphQLContext
 import graphql.execution.MergedField
 import graphql.schema.DataFetchingEnvironment
@@ -92,10 +93,10 @@ class ServiceDataFetcherSpec extends Specification {
         ServiceDataFetcher serviceDataFetcher = new ServiceDataFetcher(serviceMetadata)
 
         when:
-        DataFetcherType actualDataFetcherType = serviceDataFetcher.getDataFetcherType()
+        DataFetcherContext.DataFetcherType actualDataFetcherType = serviceDataFetcher.getDataFetcherType()
 
         then:
-        actualDataFetcherType == DataFetcherType.SERVICE_DATA_FETCHER
+        actualDataFetcherType == DataFetcherContext.DataFetcherType.SERVICE
     }
 
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/datafetcher/ServiceDataFetcherSpec.groovy
@@ -86,6 +86,23 @@ class ServiceDataFetcherSpec extends Specification {
         actualNamespace == "TestNamespace"
     }
 
+    def "returns correct service type"() {
+        given:
+        ServiceProvider serviceProvider = Mock(ServiceProvider.class)
+        serviceProvider.getSeviceType() >> ServiceProvider.ServiceType.GRAPHQL
+
+        ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)
+        serviceMetadata.getServiceProvider() >> serviceProvider
+
+        ServiceDataFetcher serviceDataFetcher = new ServiceDataFetcher(serviceMetadata)
+
+        when:
+        ServiceProvider.ServiceType actualServiceType = serviceDataFetcher.getServiceType()
+
+        then:
+        actualServiceType == ServiceProvider.ServiceType.GRAPHQL
+    }
+
     def "returns correct DataFetcherType"() {
         given:
         ServiceMetadata serviceMetadata = Mock(ServiceMetadataImpl.class)

--- a/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.federation
 
+import com.intuit.graphql.orchestrator.datafetcher.DataFetcherType
 import graphql.language.Field
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.DataLoader
@@ -13,6 +14,8 @@ class EntityDataFetcherSpec extends Specification {
 
     private final String entityName = "MockEntity"
 
+    private final String namespace = "testNamespace"
+
     private DataFetchingEnvironment dataFetchingEnvironmentMock
 
     private DataLoader dataLoaderMock
@@ -23,7 +26,23 @@ class EntityDataFetcherSpec extends Specification {
         dataFetchingEnvironmentMock = Mock(DataFetchingEnvironment)
         dataLoaderMock = Mock(DataLoader)
 
-        subjectUnderTest =  new EntityDataFetcher(entityName)
+        subjectUnderTest =  new EntityDataFetcher(entityName, namespace)
+    }
+
+    def "returns correct namespace"() {
+        when:
+        String actualNamespace = subjectUnderTest.getNamespace()
+
+        then:
+        actualNamespace == namespace
+    }
+
+    def "returns correct DataFetcherType"() {
+        when:
+        DataFetcherType actualDataFetcherType = subjectUnderTest.getDataFetcherType()
+
+        then:
+        actualDataFetcherType == DataFetcherType.ENTITY_DATA_FETCHER
     }
 
     def "load entityBatchFetcher Success"() {

--- a/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
@@ -1,5 +1,6 @@
 package com.intuit.graphql.orchestrator.federation
 
+import com.intuit.graphql.orchestrator.ServiceProvider
 import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import graphql.language.Field
 import graphql.schema.DataFetchingEnvironment
@@ -16,6 +17,8 @@ class EntityDataFetcherSpec extends Specification {
 
     private final String namespace = "testNamespace"
 
+    private final ServiceProvider.ServiceType serviceType = ServiceProvider.ServiceType.FEDERATION_SUBGRAPH
+
     private DataFetchingEnvironment dataFetchingEnvironmentMock
 
     private DataLoader dataLoaderMock
@@ -26,7 +29,7 @@ class EntityDataFetcherSpec extends Specification {
         dataFetchingEnvironmentMock = Mock(DataFetchingEnvironment)
         dataLoaderMock = Mock(DataLoader)
 
-        subjectUnderTest =  new EntityDataFetcher(entityName, namespace)
+        subjectUnderTest =  new EntityDataFetcher(entityName, namespace, serviceType)
     }
 
     def "returns correct namespace"() {
@@ -43,6 +46,14 @@ class EntityDataFetcherSpec extends Specification {
 
         then:
         actualDataFetcherType == DataFetcherContext.DataFetcherType.ENTITY_FETCHER
+    }
+
+    def "returns correct ServiceType"() {
+        when:
+        ServiceProvider.ServiceType actualServiceType = subjectUnderTest.getServiceType()
+
+        then:
+        actualServiceType == ServiceProvider.ServiceType.FEDERATION_SUBGRAPH
     }
 
     def "load entityBatchFetcher Success"() {

--- a/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityDataFetcherSpec.groovy
@@ -1,6 +1,6 @@
 package com.intuit.graphql.orchestrator.federation
 
-import com.intuit.graphql.orchestrator.datafetcher.DataFetcherType
+import com.intuit.graphql.orchestrator.xtext.DataFetcherContext
 import graphql.language.Field
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.DataLoader
@@ -39,10 +39,10 @@ class EntityDataFetcherSpec extends Specification {
 
     def "returns correct DataFetcherType"() {
         when:
-        DataFetcherType actualDataFetcherType = subjectUnderTest.getDataFetcherType()
+        DataFetcherContext.DataFetcherType actualDataFetcherType = subjectUnderTest.getDataFetcherType()
 
         then:
-        actualDataFetcherType == DataFetcherType.ENTITY_DATA_FETCHER
+        actualDataFetcherType == DataFetcherContext.DataFetcherType.ENTITY_FETCHER
     }
 
     def "load entityBatchFetcher Success"() {


### PR DESCRIPTION
# What Changed
Adding DataFetcherType in ServiceAwareDataFetcher and have EntityData Fetcher implements ServiceAwareDataFetcher

# Why
More context data that can be useful in the application, .e.g logging
