### PR TITLE
Adding error extension info to entity fetch errors

### DIFF
--- a/src/main/java/com/intuit/graphql/orchestrator/batch/EntityFetcherBatchResultTransformer.java
+++ b/src/main/java/com/intuit/graphql/orchestrator/batch/EntityFetcherBatchResultTransformer.java
@@ -22,6 +22,8 @@ public class EntityFetcherBatchResultTransformer  implements BatchResultTransfor
     private final String entityName;
     private final String extFieldName;
 
+    private final int ENTITY_PATH_IDX = 1;
+
     public static final String NO_ENTITY_FIELD = "Faulty entity response due to null _entities field";
 
     public EntityFetcherBatchResultTransformer(String providerNamespace, String entityName, String fieldName) {
@@ -38,7 +40,7 @@ public class EntityFetcherBatchResultTransformer  implements BatchResultTransfor
 
         if(CollectionUtils.isEmpty(_entities)) {
             //Should not happen; if it did, downstream did not create entity fetcher correctly or is not using DGS
-            log.warn("Provider {} is not using DGS or invalid version", providerNamespace);
+            log.warn("Provider {} is not Federation subgraph specification compliant. _entities field missing or empty in the response.", providerNamespace);
 
             throw EntityFetchingException.builder()
                     .serviceNameSpace(providerNamespace)
@@ -77,7 +79,7 @@ public class EntityFetcherBatchResultTransformer  implements BatchResultTransfor
                 //Decided to ignore if errors have no path to match field resolver. This should not happen though.
                 if(error.getPath() != null) {
                     //path is always _entities/entityIdx/entityField for entity fetch
-                    Integer pathIndex = (Integer) error.getPath().get(1);
+                    Integer pathIndex = (Integer) error.getPath().get(ENTITY_PATH_IDX);
                     Map<String, Object> entityInfo = entityList.get(pathIndex);
 
                     if(entityInfo != null) {

--- a/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityFetcherBatchResultTransformerSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/federation/EntityFetcherBatchResultTransformerSpec.groovy
@@ -9,7 +9,7 @@ import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import spock.lang.Specification
 
-import static com.intuit.graphql.orchestrator.batch.EntityFetcherBatchResultTransformer.NO_ENTITY_FIELD;
+import static com.intuit.graphql.orchestrator.batch.EntityFetcherBatchResultTransformer.NO_ENTITY_FIELD
 
 class EntityFetcherBatchResultTransformerSpec extends Specification {
     private final String serviceProviderName = "MockProvider"
@@ -19,37 +19,6 @@ class EntityFetcherBatchResultTransformerSpec extends Specification {
 
     def setup() {
         specUnderTest = new EntityFetcherBatchResultTransformer(serviceProviderName, entityTypeName, requestedField)
-    }
-
-    def "get errored fetch throws exception with mapped errors"() {
-        given:
-        Map<String, Object> batchResultData = ImmutableMap.of(
-                "keyField", "mockKeyResult",
-                "__typename", "TestEntityType"
-        )
-
-        String errorMsg1 = "Provider Generated Error Message."
-
-        List<GraphQLError> errors = Arrays.asList(
-                GraphqlErrorBuilder.newError().message(errorMsg1).build()
-        )
-
-        DataFetcherResult<Map<String, Object>> providerResultData = DataFetcherResult.<Map<String, Object>>newResult()
-                .errors(errors)
-                .build()
-
-        DataFetchingEnvironment keyFieldDFEMock = Mock(DataFetchingEnvironment.class)
-        List<DataFetchingEnvironment> dfeList = Arrays.asList(keyFieldDFEMock)
-
-        when:
-        specUnderTest.toBatchResult(providerResultData, dfeList)
-
-        then:
-        def exception = thrown(RuntimeException)
-
-        exception in EntityFetchingException
-        ((EntityFetchingException) exception).getErrorType() in ErrorType.DataFetchingException
-        exception.getMessage().contains(errorMsg1)
     }
 
     def "get null entity field throws exception"() {
@@ -181,5 +150,118 @@ class EntityFetcherBatchResultTransformerSpec extends Specification {
         batchResult.get(0).getData() == ("entityFieldResult1")
         batchResult.get(1).getData() == ("entityFieldResult2")
         batchResult.get(2).getData() == ("entityFieldResult3")
+    }
+
+    def "get errored fetch returns result with mapped errors"() {
+        given:
+        ImmutableMap<String, Object> entity1 = ImmutableMap.of(
+                "ExtEntityField","entityFieldResult1",
+                "__typename","TestEntityType"
+        )
+        HashMap<String, Object> entity2 = new HashMap<>();
+        entity2.put("ExtEntityField",null)
+        entity2.put("__typename","TestEntityType")
+
+        ImmutableMap<String, Object> entity3 = ImmutableMap.of(
+                "ExtEntityField","entityFieldResult3",
+                "__typename","TestEntityType"
+        )
+
+        List<Map<String, Object>> _entityData = Arrays.asList(entity1, entity2, entity3)
+
+        Map<String, Object> providerResultData = ImmutableMap.of(
+                "_entities", _entityData
+        )
+
+        String errorMsg1 = "Provider Generated Error Message."
+        GraphQLError error = GraphqlErrorBuilder.newError()
+                .message(errorMsg1)
+                .path(Arrays.asList(
+                        "_entities",
+                        Integer.valueOf(1),
+                        "keyField"
+                    )
+                )
+                .extensions(new HashMap<String, Object>())
+                .build()
+
+        DataFetcherResult<Map<String, Object>> providerResult = DataFetcherResult.<Map<String, Object>>newResult()
+                .data(providerResultData)
+                .errors(Arrays.asList(error))
+                .build()
+
+        DataFetchingEnvironment keyFieldDFEMock = Mock(DataFetchingEnvironment.class)
+
+        List<DataFetchingEnvironment> dfeList = Arrays.asList(keyFieldDFEMock)
+
+        when:
+        List<DataFetcherResult<Object>> batchResult = specUnderTest.toBatchResult(providerResult, dfeList)
+
+        then:
+        batchResult.size() == 3
+        batchResult.get(0).getData() == "entityFieldResult1"
+        batchResult.get(0).getErrors().size() == 0
+
+        batchResult.get(1).getData() == null
+        batchResult.get(1).getErrors().size() == 1
+        batchResult.get(1).getErrors().get(0).message == errorMsg1
+        batchResult.get(1).getErrors().get(0).extensions.get("fieldName") == "ExtEntityField"
+        batchResult.get(1).getErrors().get(0).extensions.get("serviceNamespace") == "MockProvider"
+        batchResult.get(1).getErrors().get(0).extensions.get("parentTypename") == "MockEntity"
+
+        batchResult.get(2).getData() == "entityFieldResult3"
+        batchResult.get(2).getErrors().size() == 0
+    }
+
+    def "fetch with error with no path is ignored"() {
+        given:
+        ImmutableMap<String, Object> entity1 = ImmutableMap.of(
+                "ExtEntityField","entityFieldResult1",
+                "__typename","TestEntityType"
+        )
+        HashMap<String, Object> entity2 = ImmutableMap.of(
+                "ExtEntityField","entityFieldResult2",
+                "__typename","TestEntityType"
+        )
+
+        ImmutableMap<String, Object> entity3 = ImmutableMap.of(
+                "ExtEntityField","entityFieldResult3",
+                "__typename","TestEntityType"
+        )
+
+        List<Map<String, Object>> _entityData = Arrays.asList(entity1, entity2, entity3)
+
+        Map<String, Object> providerResultData = ImmutableMap.of(
+                "_entities", _entityData
+        )
+
+        String errorMsg1 = "Provider Generated Error Message."
+        GraphQLError error = GraphqlErrorBuilder.newError()
+                .message(errorMsg1)
+                .extensions(new HashMap<String, Object>())
+                .build()
+
+        DataFetcherResult<Map<String, Object>> providerResult = DataFetcherResult.<Map<String, Object>>newResult()
+                .data(providerResultData)
+                .errors(Arrays.asList(error))
+                .build()
+
+        DataFetchingEnvironment keyFieldDFEMock = Mock(DataFetchingEnvironment.class)
+
+        List<DataFetchingEnvironment> dfeList = Arrays.asList(keyFieldDFEMock)
+
+        when:
+        List<DataFetcherResult<Object>> batchResult = specUnderTest.toBatchResult(providerResult, dfeList)
+
+        then:
+        batchResult.size() == 3
+        batchResult.get(0).getData() == "entityFieldResult1"
+        batchResult.get(0).getErrors().size() == 0
+
+        batchResult.get(1).getData() == "entityFieldResult2"
+        batchResult.get(1).getErrors().size() == 0
+
+        batchResult.get(2).getData() == "entityFieldResult3"
+        batchResult.get(2).getErrors().size() == 0
     }
 }


### PR DESCRIPTION
# What Changed
Adding error extension info to errors

# Why
Allow partial data with reasons why instead of exception

Todo:

- [x] Add tests
- [x] Add docs