### PR TITLE
test: add assert for outgoing queries in integration tests - (Issue #175)

### DIFF
--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/AliasFragmentSpreadWithNestedSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/AliasFragmentSpreadWithNestedSpec.groovy
@@ -59,15 +59,19 @@ class AliasFragmentSpreadWithNestedSpec extends BaseIntegrationTestSpecification
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        //query QUERY {
+        //      a {b {foo:c(a:"foo") {d {f1}}}}
+        //      a {b {bar:c(a:"bar") {d {f2}}}}
+        // }
+        compareQueryToExecutionInput(null,
+                                    "queryQUERY{a{b{foo:c(a:\"foo\"){d{f1}}bar:c(a:\"bar\"){d{f2}}}}}", service1)
+        compareQueryToExecutionInput(null,null, service2)
+
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.a?.b?.foo?.d?.f1 instanceof String && data.a?.b?.foo?.d?.f1 == "foo1"
         data.a?.b?.bar?.d?.f2 instanceof String && data.a?.b?.bar?.d?.f2 == "bar2"
 
-        //query QUERY {
-        //      a {b {foo:c(a:"foo") {d {f1}}}}
-        //      a {b {bar:c(a:"bar") {d {f2}}}}
-        // }
     }
 
     def "Fragments used at the type-merge level with arguments"() {
@@ -92,6 +96,15 @@ class AliasFragmentSpreadWithNestedSpec extends BaseIntegrationTestSpecification
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        //    fragment fr on C {d {f1 f2}}
+        //
+        //    query QUERY {
+        //        a {b {foo:c(a:"foo") {...fr}}}
+        //        a {b {bar:c(a:"bar") {...fr}}}
+        //    }
+        compareQueryToExecutionInput(null,
+                "fragmentfronC{d{f1f2}}queryQUERY{a{b{foo:c(a:\"foo\"){...fr}bar:c(a:\"bar\"){...fr}}}}", service1)
+        compareQueryToExecutionInput(null,null, service2)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.a?.b?.foo?.d?.f1 instanceof String && data.a?.b?.foo?.d?.f1 == "foo1"
@@ -100,12 +113,7 @@ class AliasFragmentSpreadWithNestedSpec extends BaseIntegrationTestSpecification
         data.a?.b?.bar?.d?.f2 instanceof String && data.a?.b?.bar?.d?.f2 == "bar2"
     }
 
-//    fragment fr on C {d {f1 f2}}
-//
-//    query QUERY {
-//        a {b {foo:c(a:"foo") {...fr}}}
-//        a {b {bar:c(a:"bar") {...fr}}}
-//    }
+
     def "Basic Nested"() {
         given:
         def mockServiceResponseBasic1 = [
@@ -150,6 +158,15 @@ class AliasFragmentSpreadWithNestedSpec extends BaseIntegrationTestSpecification
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        //    fragment fr on C {d {f1 f2}}
+        //
+        //    query QUERY {
+        //        a {b {foo:c(a:"foo") {...fr}}}
+        //        a {b {bar:c(a:"bar") {...fr}}}
+        //    }
+        compareQueryToExecutionInput(null,
+                "queryQUERY{a{b{c(a:\"foo\"){d{f1f2}}}e{f1}}}", service1)
+        compareQueryToExecutionInput(null,"queryQUERY{a{b{c(a:\"foo\"){f{f1f2}}}}}", service2)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.a?.b?.c?.d?.f1 instanceof String && data.a?.b?.c?.d?.f1 == "foo1"
@@ -158,11 +175,5 @@ class AliasFragmentSpreadWithNestedSpec extends BaseIntegrationTestSpecification
         data.a?.b?.c?.f?.f2 instanceof String && data.a?.b?.c?.f?.f2 == "bar2"
         data.a?.e?.f1 instanceof String && data.a?.e?.f1 == "eoo"
     }
-
-//    fragment fr on C {d {f1 f2}}
-//
-//    query QUERY {
-//        a {b {foo:c(a:"foo") {...fr}}}
-//        a {b {bar:c(a:"bar") {...fr}}}
-//    }
+    
 }

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/InterfaceImplementInterfaceSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/InterfaceImplementInterfaceSpec.groovy
@@ -1,6 +1,7 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.schema.GraphQLInterfaceType
@@ -130,6 +131,9 @@ class InterfaceImplementInterfaceSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                "queryQUERY{pets{edges{...onDogEdge{node{idnameisServiceDog__typename}__typename}__typename}__typename}}",
+                (SimpleMockServiceProvider) testService)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
 

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/JavaPrimitiveScalarSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/JavaPrimitiveScalarSpec.groovy
@@ -1,6 +1,8 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.schema.Operation
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import helpers.BaseIntegrationTestSpecification
@@ -57,6 +59,7 @@ class JavaPrimitiveScalarSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(Operation.QUERY, graphqlQuery, (SimpleMockServiceProvider) testService);
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.a instanceof Long && data.a == Long.MAX_VALUE

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/NestedFieldResolverSpec.groovy
@@ -120,6 +120,14 @@ class NestedFieldResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        specUnderTest.runtimeGraph.codeRegistry.dataFetcherMap.size() == 6
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "BObjectType.bObjectField")
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "Query.cTopField")
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "Query._namespace")
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "Query.arootField")
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "Query.bTopField")
+        checkIfKeyExistsInDataFetcherMap(specUnderTest, "AObjectType.cTopField")
+
         executionResult.getErrors().isEmpty()
         executionResult?.data?.bTopField?.size() == 2
         executionResult?.data?.bTopField[0]?.size() == 2


### PR DESCRIPTION
### What Changed
  - Added some sample asserts on existing integration tests
### Why
  - To verify if the outgoing queries to the orchestrated micro-services is in the expected pattern
  - Relates to
    - Issue #175 
    - Issue #177
## Todo
  - Verify if the tests fulfill the ask plus any pending refactors