### PR TITLE
test: add assert for outgoing queries in integration tests - (Issue #179)

### DIFF
--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/CustomScalarsSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/CustomScalarsSpec.groovy
@@ -1,7 +1,6 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
-import com.intuit.graphql.orchestrator.schema.Operation
 import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/CustomScalarsSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/CustomScalarsSpec.groovy
@@ -1,6 +1,8 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.schema.Operation
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.schema.GraphQLArgument
@@ -64,6 +66,8 @@ class CustomScalarsSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                "query QUERY { uuid url }", (SimpleMockServiceProvider) testService)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.uuid instanceof String && data.uuid == "123e4567-e89b-12d3-a456-426614174000"

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/DeprecatedSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/DeprecatedSpec.groovy
@@ -1,7 +1,6 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
-import com.intuit.graphql.orchestrator.schema.Operation
 import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/DeprecatedSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/DeprecatedSpec.groovy
@@ -1,6 +1,8 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.schema.Operation
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import helpers.BaseIntegrationTestSpecification
@@ -53,6 +55,9 @@ class DeprecatedSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                'query TestQuery($a1: String, $a2: InputType) {x(arg1: $a1, arg2: $a2)}',
+                (SimpleMockServiceProvider) testService)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.x instanceof String && data.x == "some value for x"

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/DirectivesOnVariableDefinitionSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/DirectivesOnVariableDefinitionSpec.groovy
@@ -1,6 +1,7 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.language.Directive
@@ -51,6 +52,9 @@ class DirectivesOnVariableDefinitionSpec extends BaseIntegrationTestSpecificatio
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                'query TestQuery($stringVar: String @directiveOnVar(dirArg : "dirArgValue")){field(stringArg: $stringVar)}',
+                (SimpleMockServiceProvider) testService)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.field instanceof String && data.field == "SomeString"

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/DownstreamVariableSplittingSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/DownstreamVariableSplittingSpec.groovy
@@ -1,6 +1,7 @@
 package com.intuit.graphql.orchestrator.integration
 
 import com.intuit.graphql.orchestrator.GraphQLOrchestrator
+import com.intuit.graphql.orchestrator.testhelpers.SimpleMockServiceProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import helpers.BaseIntegrationTestSpecification
@@ -69,6 +70,12 @@ class DownstreamVariableSplittingSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                'query TestQuery($objectVarA: InputA){fieldA(objectArgA: $objectVarA)}',
+                (SimpleMockServiceProvider) testServiceA)
+        compareQueryToExecutionInput(null,
+                'query TestQuery($stringVarB: String){fieldB(stringArgB: $stringVarB)}',
+                (SimpleMockServiceProvider) testServiceB)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.fieldA instanceof String && data.fieldA == "SomeStringA"

--- a/src/test/groovy/com/intuit/graphql/orchestrator/integration/XtextConflictResolverSpec.groovy
+++ b/src/test/groovy/com/intuit/graphql/orchestrator/integration/XtextConflictResolverSpec.groovy
@@ -178,6 +178,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                "query QUERY { a { test alpha } }", (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
 
         specUnderTest.runtimeGraph?.getType("MyType1") != null
@@ -215,6 +219,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                "query QUERY { b { test beta } }", (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
 
         specUnderTest.runtimeGraph?.getType("MyType1") != null
@@ -305,6 +313,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                "query QUERY { a { test alpha } }", (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
 
         specUnderTest.runtimeGraph?.getExecutableSchema().getType("Query").getFieldDefinition("b") == null
@@ -342,6 +354,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                "query QUERY { bb { test beta } }", (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
 
         specUnderTest.runtimeGraph?.getExecutableSchema().getType("Query").getFieldDefinition("b") == null
@@ -450,6 +466,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                "fragment NameFragment on IName { name } query QUERY { a {...NameFragment test alpha}}", (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.a?.name instanceof String && data.a?.name == "A A"
@@ -487,6 +507,10 @@ class XtextConflictResolverSpec extends BaseIntegrationTestSpecification {
         ExecutionResult executionResult = specUnderTest.execute(executionInput).get()
 
         then:
+        compareQueryToExecutionInput(null,
+                null, (SimpleMockServiceProvider) serviceA)
+        compareQueryToExecutionInput(null,
+                "fragment NameFragment on ITheName { name } query QUERY { b {...NameFragment test beta}}", (SimpleMockServiceProvider) serviceB)
         executionResult.getErrors().isEmpty()
         Map<String, Object> data = executionResult.getData()
         data.b?.name instanceof String && data.b?.name == "B B"


### PR DESCRIPTION
# What Changed
* Added some sample asserts on existing integration tests

# Why
* To verify if the outgoing queries to the orchestrated micro-services is in the expected pattern
* Relates to
   #179 
   #177 

Todo:

- [ ] Add tests
- [ ] Add docs